### PR TITLE
Simplify speed control code

### DIFF
--- a/scripts/algorithmTools.js
+++ b/scripts/algorithmTools.js
@@ -7,7 +7,3 @@ algorithmTools.delay = function(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-algorithmTools.switchSpeedControl = function() {
-  this.speedControl = {1:2,2:4,4:1}[this.speedControl];
-}
-

--- a/scripts/gui.js
+++ b/scripts/gui.js
@@ -54,11 +54,9 @@ playButton.addEventListener("click", async ()=>{
 })
 
 
-let speed = 1;
 document.getElementById("speedButton").addEventListener("click", async ()=>{
-  speed = {1:2,2:4,4:1}[speed];
-  document.getElementById("speedText").innerText = "X"+{1:"1",2:"2",4:"4"}[speed];
-  algorithmTools.switchSpeedControl();
+  algorithmTools.speedControl = {1:2,2:4,4:1}[algorithmTools.speedControl];
+  document.getElementById("speedText").innerText = "X"+{1:"1",2:"2",4:"4"}[algorithmTools.speedControl];
 })
 
 


### PR DESCRIPTION
- Replace unnecessary `speed` variable with `algorithmTools.speedControl` property, in **gui.js**.
- Remove unnecessary `algorithmTools.switchSpeedControl` method, in **algorithmTools.js**.

Fixes #3 